### PR TITLE
Fix leftover browser-tools references

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -156,7 +156,7 @@ npm run validate
 - `scripts/macos/start-server.sh` - Start server shell script
 
 ### Linux
-- `scripts/linux/browser-tools.service` - Systemd service file
+- `scripts/linux/webai-server.service` - Systemd service file
 
 ## Troubleshooting
 

--- a/scripts/diagnose.js
+++ b/scripts/diagnose.js
@@ -4,7 +4,7 @@
  * Browser Tools MCP Diagnostic Tool
  *
  * Comprehensive diagnostic tool to identify and troubleshoot common issues
- * with browser-tools-mcp setup and connectivity.
+ * with webai-mcp setup and connectivity.
  */
 
 import { execSync, spawn } from 'child_process';
@@ -118,7 +118,7 @@ class DiagnosticTool {
           this.log('Browser Tools packages found globally', 'green', ICONS.success);
         } else {
           this.log('Browser Tools packages not installed globally', 'yellow', ICONS.warning);
-          this.recommendations.push('Consider installing globally: npm install -g @cpjet64/browser-tools-mcp @cpjet64/browser-tools-server');
+          this.recommendations.push('Consider installing globally: npm install -g @cpjet64/webai-mcp @cpjet64/webai-server');
         }
       } catch (error) {
         this.log('Could not check global packages', 'yellow', ICONS.warning);
@@ -185,7 +185,7 @@ class DiagnosticTool {
       } else {
         this.log('No browser-tools processes found', 'yellow', ICONS.warning);
         this.results.processes = { status: 'none', count: 0 };
-        this.recommendations.push('Start the browser-tools-server: npx @cpjet64/browser-tools-server');
+        this.recommendations.push('Start the webai-server: npx @cpjet64/webai-server');
       }
 
     } catch (error) {
@@ -256,8 +256,8 @@ class DiagnosticTool {
 
     try {
       // Check if dist directories exist
-      const mcpDistPath = path.join(process.cwd(), 'browser-tools-mcp', 'dist');
-      const serverDistPath = path.join(process.cwd(), 'browser-tools-server', 'dist');
+      const mcpDistPath = path.join(process.cwd(), 'webai-mcp', 'dist');
+      const serverDistPath = path.join(process.cwd(), 'webai-server', 'dist');
 
       const mcpBuilt = fs.existsSync(mcpDistPath);
       const serverBuilt = fs.existsSync(serverDistPath);
@@ -266,14 +266,14 @@ class DiagnosticTool {
         this.log('MCP Server build artifacts found', 'green', ICONS.success);
       } else {
         this.log('MCP Server not built', 'red', ICONS.error);
-        this.issues.push('MCP Server needs to be built. Run: cd browser-tools-mcp && npm run build');
+        this.issues.push('MCP Server needs to be built. Run: cd webai-mcp && npm run build');
       }
 
       if (serverBuilt) {
         this.log('Browser Tools Server build artifacts found', 'green', ICONS.success);
       } else {
-        this.log('Browser Tools Server not built', 'red', ICONS.error);
-        this.issues.push('Browser Tools Server needs to be built. Run: cd browser-tools-server && npm run build');
+        this.log('WebAI Server not built', 'red', ICONS.error);
+        this.issues.push('WebAI Server needs to be built. Run: cd webai-server && npm run build');
       }
 
       this.results.buildStatus = {
@@ -326,8 +326,8 @@ class DiagnosticTool {
     }
 
     if (!serverFound) {
-      this.log('No Browser Tools Server found', 'red', ICONS.error);
-      this.issues.push('Browser Tools Server is not running. Start it with: npx @cpjet64/browser-tools-server');
+      this.log('No WebAI Server found', 'red', ICONS.error);
+      this.issues.push('WebAI Server is not running. Start it with: npx @cpjet64/webai-server');
       this.results.connectivity = { status: 'no_server' };
     } else {
       this.results.connectivity = { status: 'connected', server: serverDetails };
@@ -412,7 +412,7 @@ class DiagnosticTool {
     const hasRecommendations = this.recommendations.length > 0;
 
     if (!hasErrors && !hasRecommendations) {
-      this.log('All checks passed! Your browser-tools-mcp setup looks good.', 'green', ICONS.success);
+      this.log('All checks passed! Your webai-mcp setup looks good.', 'green', ICONS.success);
     } else if (hasErrors) {
       this.log(`Found ${this.issues.length} issue(s) that need attention:`, 'red', ICONS.error);
       this.issues.forEach((issue, index) => {
@@ -435,13 +435,13 @@ class DiagnosticTool {
 
       if (!this.results.buildStatus?.mcpBuilt || !this.results.buildStatus?.serverBuilt) {
         this.log('1. Build the packages:', 'cyan', ICONS.tools);
-        this.log('   cd browser-tools-mcp && npm install && npm run build', 'blue', '   ');
-        this.log('   cd ../browser-tools-server && npm install && npm run build', 'blue', '   ');
+        this.log('   cd webai-mcp && npm install && npm run build', 'blue', '   ');
+        this.log('   cd ../webai-server && npm install && npm run build', 'blue', '   ');
       }
 
       if (this.results.connectivity?.status === 'no_server') {
         this.log('2. Start the server:', 'cyan', ICONS.tools);
-        this.log('   npx @cpjet64/browser-tools-server', 'blue', '   ');
+        this.log('   npx @cpjet64/webai-server', 'blue', '   ');
       }
 
       if (this.results.chromeExtension?.status === 'ready') {

--- a/scripts/platform-setup.js
+++ b/scripts/platform-setup.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Platform-Specific Setup Utilities for Browser Tools MCP
+ * Platform-Specific Setup Utilities for WebAI-MCP
  * 
  * Handles platform-specific configurations, optimizations,
  * and troubleshooting for Windows, macOS, and Linux.
@@ -218,7 +218,7 @@ class PlatformSetup {
       
       // Create start script
       const startScript = `@echo off
-echo Starting Browser Tools MCP Server...
+echo Starting WebAI-MCP Server...
 set MIDDLEWARE_PORT=3025
 
 :: Kill existing processes
@@ -227,7 +227,7 @@ for /f "tokens=5" %%a in ('netstat -ano ^| findstr ":%MIDDLEWARE_PORT%"') do (
 )
 
 :: Start middleware server
-start "BrowserTools Server" cmd /c "npx @cpjet64/browser-tools-server"
+start "WebAI Server" cmd /c "npx @cpjet64/webai-server"
 
 :: Wait and start MCP server if needed
 timeout /t 3 /nobreak > nul
@@ -239,7 +239,7 @@ pause`;
       
       // Create diagnostic script
       const diagScript = `@echo off
-echo Running Browser Tools MCP Diagnostics...
+echo Running WebAI-MCP Diagnostics...
 node scripts/diagnose.js
 pause`;
 
@@ -355,14 +355,14 @@ pause`;
       
       // Create start script
       const startScript = `#!/bin/bash
-echo "Starting Browser Tools MCP Server..."
-export MIDDLEWARE_PORT=3025
+echo "Starting WebAI-MCP Server..."
+      export MIDDLEWARE_PORT=3025
 
 # Kill existing processes
 lsof -ti:$MIDDLEWARE_PORT | xargs kill -9 2>/dev/null || true
 
 # Start server
-npx @cpjet64/browser-tools-server &
+npx @cpjet64/webai-server &
 
 echo "Server starting on port $MIDDLEWARE_PORT"
 echo "Check terminal output for status"`;
@@ -454,24 +454,24 @@ echo "Check terminal output for status"`;
       
       // Create systemd service file
       const serviceFile = `[Unit]
-Description=Browser Tools MCP Server
+Description=WebAI-MCP Server
 After=network.target
 
 [Service]
 Type=simple
 User=\${USER}
 WorkingDirectory=\${PWD}
-ExecStart=/usr/bin/npx @cpjet64/browser-tools-server
+ExecStart=/usr/bin/npx @cpjet64/webai-server
 Restart=always
 RestartSec=10
 
 [Install]
 WantedBy=multi-user.target`;
 
-      fs.writeFileSync(path.join(scriptDir, 'browser-tools.service'), serviceFile);
-      
+      fs.writeFileSync(path.join(scriptDir, 'webai-server.service'), serviceFile);
+
       this.log('Created Linux systemd service file', 'green', ICONS.success);
-      this.log('To install: sudo cp scripts/linux/browser-tools.service /etc/systemd/system/', 'blue', '  ');
+      this.log('To install: sudo cp scripts/linux/webai-server.service /etc/systemd/system/', 'blue', '  ');
       
     } catch (error) {
       this.log('Failed to create Linux scripts', 'red', ICONS.error);

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -198,8 +198,8 @@ class SetupTool {
     this.logSection('Building Packages');
 
     const packages = [
-      { name: 'MCP Server', path: 'browser-tools-mcp' },
-      { name: 'Browser Tools Server', path: 'browser-tools-server' }
+      { name: 'MCP Server', path: 'webai-mcp' },
+      { name: 'WebAI Server', path: 'webai-server' }
     ];
 
     for (const pkg of packages) {
@@ -347,7 +347,7 @@ class SetupTool {
 
     console.log();
     this.log('Next steps:', 'cyan', ICONS.info);
-    this.log('1. Start the server: npx @cpjet64/browser-tools-server', 'blue', '  ');
+    this.log('1. Start the server: npx @cpjet64/webai-server', 'blue', '  ');
     this.log('2. Install the Chrome extension from the chrome-extension folder', 'blue', '  ');
     this.log('3. Configure your MCP client (Cursor, Claude Desktop, etc.)', 'blue', '  ');
     console.log();

--- a/scripts/validate-installation.js
+++ b/scripts/validate-installation.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 /**
- * Installation Validation Script for Browser Tools MCP
+ * Installation Validation Script for WebAI-MCP
  *
- * Comprehensive validation of the entire Browser Tools MCP setup
+ * Comprehensive validation of the entire WebAI-MCP setup
  * including dependencies, builds, configuration, and functionality.
  */
 
@@ -12,7 +12,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import DiagnosticTool from './diagnose.js';
-import { VersionChecker } from '../browser-tools-mcp/version-checker.js';
+import { VersionChecker } from '../webai-mcp/version-checker.js';
 
 const COLORS = {
   reset: '\x1b[0m',
@@ -74,7 +74,7 @@ class InstallationValidator {
   }
 
   async runValidation() {
-    this.log('Browser Tools MCP Installation Validator', 'bright', ICONS.rocket);
+    this.log('WebAI-MCP Installation Validator', 'bright', ICONS.rocket);
     this.log(`Platform: ${os.platform()} ${os.arch()}`, 'blue', ICONS.info);
     this.log(`Node.js: ${process.version}`, 'blue', ICONS.info);
     console.log();
@@ -228,8 +228,8 @@ class InstallationValidator {
 
     // Check for build artifacts
     const buildDirs = [
-      'browser-tools-mcp/dist',
-      'browser-tools-server/dist'
+      'webai-mcp/dist',
+      'webai-server/dist'
     ];
 
     for (const buildDir of buildDirs) {
@@ -288,8 +288,8 @@ class InstallationValidator {
     this.logSection('Build Validation');
 
     const packages = [
-      { name: 'MCP Server', path: 'browser-tools-mcp' },
-      { name: 'Browser Tools Server', path: 'browser-tools-server' }
+      { name: 'MCP Server', path: 'webai-mcp' },
+      { name: 'WebAI Server', path: 'webai-server' }
     ];
 
     for (const pkg of packages) {
@@ -405,7 +405,7 @@ class InstallationValidator {
       if (response.ok) {
         const identity = await response.json();
         if (identity.signature === 'mcp-browser-connector-24x7') {
-          this.recordResult('functionality', 'pass', 'Browser Tools Server is running and responding');
+          this.recordResult('functionality', 'pass', 'WebAI Server is running and responding');
         } else {
           this.recordResult('functionality', 'warn', 'Server running but wrong signature');
         }
@@ -413,8 +413,8 @@ class InstallationValidator {
         this.recordResult('functionality', 'warn', 'Server running but not responding correctly');
       }
     } catch (error) {
-      this.recordResult('functionality', 'warn', 'Browser Tools Server not running');
-      this.recommendations.push('Start the server: npx @cpjet64/browser-tools-server');
+      this.recordResult('functionality', 'warn', 'WebAI Server not running');
+      this.recommendations.push('Start the server: npx @cpjet64/webai-server');
     }
   }
 

--- a/webai-mcp/error-handler.ts
+++ b/webai-mcp/error-handler.ts
@@ -174,9 +174,9 @@ export class ErrorHandler {
     switch (type) {
       case 'connection':
         solutions.push({
-          title: 'Start Browser Tools Server',
+          title: 'Start WebAI Server',
           description: 'The most common cause is that the server is not running.',
-          commands: ['npx @cpjet64/browser-tools-server'],
+          commands: ['npx @cpjet64/webai-server'],
           priority: 'high'
         });
 
@@ -301,8 +301,8 @@ export class ErrorHandler {
       title: 'Get Help',
       description: 'If the issue persists, check the documentation or report the issue.',
       links: [
-        'https://github.com/cpjet64/browser-tools-mcp/issues',
-        'https://github.com/cpjet64/browser-tools-mcp/blob/main/README.md'
+        'https://github.com/cpjet64/webai-mcp/issues',
+        'https://github.com/cpjet64/webai-mcp/blob/main/README.md'
       ],
       priority: 'low'
     });


### PR DESCRIPTION
## Summary
- replace old package names in error handler and setup scripts
- rename generated Linux service file
- update installation validator messages
- update script documentation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a5afdb6c83218b1b2427bc1bdfa4